### PR TITLE
Update runtime to 47

### DIFF
--- a/re.sonny.OhMySVG.json
+++ b/re.sonny.OhMySVG.json
@@ -1,7 +1,7 @@
 {
   "id": "re.sonny.OhMySVG",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "re.sonny.OhMySVG",
   "finish-args": [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.